### PR TITLE
Add continuous integration job to the project

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,25 @@
+name: Pull-Request CI
+
+on:
+  pull_request:
+    branches:
+      - master
+      - dev
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+          java-package: jdk
+          architecture: x64
+
+      - name: Build
+        run: mvn compile --file complete/pom.xml
+
+      - name: Run Tests
+        run: mvn test --file complete/pom.xml


### PR DESCRIPTION
## What the change is

I created a GitHub Action that builds and runs the tests for this project on pull requests made to either the `master` or `dev` branches.

## Thought process

In the action, I specify that it should only run on pull requests to `master` or `dev`. This is so that these jobs will only be queued on significant changes to branches that could potentially block new feature branches from being made. I also made sure to separate the build and test steps so that it's clear in the Action log where something went wrong if it does.