### PR TITLE
Java 21 master migration with gitignore

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK 1.8
+      - name: Setup JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: '8'
+          java-version: '21'
           java-package: jdk
           architecture: x64
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,93 @@
+# Created by https://www.toptal.com/developers/gitignore/api/maven,eclipse
+# Edit at https://www.toptal.com/developers/gitignore?templates=maven,eclipse
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# End of https://www.toptal.com/developers/gitignore/api/maven,eclipse
+
 # Compiled class file
 *.class
 

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.9.RELEASE</version>
+		<version>3.2.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.theenergymashuplab</groupId>
@@ -34,11 +34,23 @@ limitations under the License.
 	<description>EML project for Spring Boot</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>21</java.version>
 		<start-class>org.theenergymashuplab.cts.EnergyApplication</start-class>
 	</properties>
 
 	<dependencies>
+		<!-- POM CHANGES FOR MIGRATION TO SPRING BOOT 3 -->
+		<dependency> <!-- FOR SPRING BOOT >=2.3 spring-boot-starter-web no longer comes with this needed dependency by default -->
+  			<groupId>org.springframework.boot</groupId>
+  			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		
+		<dependency> <!-- FOR SPRING BOOT >=2.7, the coordinates for up-to-date mysql dependency changed -->
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		
 		<!-- spring security -->
 
 		<!-- spring security test -->
@@ -60,11 +72,6 @@ limitations under the License.
 			<scope>runtime</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<scope>runtime</scope>
-		</dependency>
 		<!--Spring boot starter web-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/PositionManager.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/PositionManager.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/complete/src/main/java/org/theenergymashuplab/cts/dao/PositionService.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/dao/PositionService.java
@@ -25,7 +25,7 @@ package org.theenergymashuplab.cts.dao;
 import java.time.Instant;
 import java.util.List;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;

--- a/complete/src/main/java/org/theenergymashuplab/cts/model/PositionManagerModel.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/model/PositionManagerModel.java
@@ -26,13 +26,13 @@ import java.time.Instant;
 
 // TODO extend columns here
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 @Table(name="Position")

--- a/complete/src/main/java/org/theenergymashuplab/cts/repository/PositionRepository.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/repository/PositionRepository.java
@@ -28,16 +28,16 @@ import org.theenergymashuplab.cts.model.PositionManagerModel;
 
 public interface PositionRepository extends JpaRepository<PositionManagerModel, Long>{
 
-	@Query(nativeQuery = true, value = "select * from Position p where p.Position_id=:id")
+	@Query(nativeQuery = true, value = "select * from position p where p.position_id=:id")
 	public PositionManagerModel getStatus(@Param("id") long id);
 	
 	// New updated queries.
-	@Query(nativeQuery = true, value = "select * from Position p where (p.position_Party = :positionParty) AND ((p.start_time <= :sTime AND p.end_time > :sTime) OR (p.start_time < :sTime_plus_dur AND p.start_time > :sTime))")
+	@Query(nativeQuery = true, value = "select * from position p where (p.position_Party = :positionParty) AND ((p.start_time <= :sTime AND p.end_time > :sTime) OR (p.start_time < :sTime_plus_dur AND p.start_time > :sTime))")
 	public List<PositionManagerModel> getPositionforDuration(@Param("positionParty") long positionParty,
 			@Param("sTime") Instant sTime,
 			@Param("sTime_plus_dur") Instant sTime_plus_dur);
 	
-	@Query(nativeQuery = true, value = "select * from Position p where p.position_Party = :positionParty AND start_time = :sTime AND end_time = :sTime_plus_dur")
+	@Query(nativeQuery = true, value = "select * from position p where p.position_Party = :positionParty AND start_time = :sTime AND end_time = :sTime_plus_dur")
 	public List<PositionManagerModel> getPositionforUpdate(
 			@Param("positionParty") long positionParty,
 			@Param("sTime") Instant sTime,
@@ -45,7 +45,7 @@ public interface PositionRepository extends JpaRepository<PositionManagerModel, 
 	
 	@Modifying
 	@Transactional
-	@Query(nativeQuery = true, value = "update Position p set p.Quantity = p.Quantity + :newquantity where p.position_Party = :positionParty AND start_time = :sTime AND end_time = :sTime_plus_dur")
+	@Query(nativeQuery = true, value = "update position p set p.Quantity = p.Quantity + :newquantity where p.position_Party = :positionParty AND start_time = :sTime AND end_time = :sTime_plus_dur")
 	public int updatePositionforDuration(
 			@Param("positionParty") long positionParty,
 			@Param("sTime") Instant sTime,

--- a/complete/src/main/resources/application.properties
+++ b/complete/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.password = capstone@123
 
 ## Hibernate Properties
 # The SQL dialect makes Hibernate generate better SQL for the chosen database
-spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL5Dialect
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQLDialect
 #spring.jpa.show-sql=true
 #spring.jpa.properties.hibernate.format_sql=true
 


### PR DESCRIPTION
This branch replicates the changes of the `java-21-master-migration` branch, but ensuring that files that shouldn't be tracked remained untracked.

(From the `java-21-master-migration` pull request) Migrate code base (on master) to Java 21 and Spring Boot 3.2. Most changes were made to the `pom.xml`, but some minor changes to the code base were made as well (such as changing all instances of `javax` in imports to `jakarta`, like `javax.persistence` to `jakarta.persistence`)
