### PR TITLE
Implementation of Stream Tenders and Stream Quotes into EML-CTS

### DIFF
--- a/complete/src/main/java/org/theenergymashuplab/cts/BridgeInstant.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/BridgeInstant.java
@@ -22,11 +22,11 @@ import java.time.format.DateTimeFormatter;
 
 public class BridgeInstant {
 	private String instantString = new String("");
-//	private Instant instant;
+	private Instant instant;
 	private static final DateTimeFormatter INSTANT_INSTRUMENT_FORMATTER =
 		DateTimeFormatter.ofPattern("MMddHHmm").withZone(ZoneId.of("Z"));
 
-	BridgeInstant() {
+	public BridgeInstant() {
 	}
 
 	public BridgeInstant(Instant javaInstant) {
@@ -49,6 +49,11 @@ public class BridgeInstant {
 
 	public void setInstantString(String instantString) {
 		this.instantString = instantString;
+	}
+
+	public void setInstant(Instant instant){
+		this.instant = instant;
+		this.instantString = instant.toString();
 	}
 
 	//	Code from Parity CtsBridge uses mehods not available here

--- a/complete/src/main/java/org/theenergymashuplab/cts/BridgeInterval.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/BridgeInterval.java
@@ -55,7 +55,7 @@ package org.theenergymashuplab.cts;
 			this.dtStart = new BridgeInstant(ctsInterval.dtStart);
 		}
 
-		Interval asInterval() {
+		public Interval asInterval() {
 			return new Interval(durationInMinutes, dtStart.asInstant());
 		}
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/CtsStreamIntervalType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/CtsStreamIntervalType.java
@@ -54,5 +54,4 @@ public class CtsStreamIntervalType {
     public void setStreamUid(int streamUid) {
         this.streamUid = streamUid;
     }
-
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/CtsStreamType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/CtsStreamType.java
@@ -24,13 +24,11 @@ public class CtsStreamType {
 	 * The duration of each StreamInterval
 	 */
 	private Interval streamIntervalDuration;
-	private BridgeInterval streamBridgeIntervalDuration;
 	/**
 	 * Array of StreamIntervals.
 	 */
 	private List<CtsStreamIntervalType> streamIntervals;
 	private Instant streamStart;
-	private BridgeInstant streamStartBridge;
 
 	public CtsStreamType(){
 	}
@@ -68,12 +66,4 @@ public class CtsStreamType {
 	public void setStreamStart(Instant streamStart) {
 		this.streamStart = streamStart;
 	}
-
-	public void setStreamBridgeIntervalDuration(BridgeInterval streamBridgeIntervalDuration){
-		this.streamBridgeIntervalDuration = streamBridgeIntervalDuration;
-		this.streamIntervalDuration = streamBridgeIntervalDuration.asInterval();
-	}
-
-
-
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/CtsStreamType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/CtsStreamType.java
@@ -24,11 +24,13 @@ public class CtsStreamType {
 	 * The duration of each StreamInterval
 	 */
 	private Interval streamIntervalDuration;
+	private BridgeInterval streamBridgeIntervalDuration;
 	/**
 	 * Array of StreamIntervals.
 	 */
 	private List<CtsStreamIntervalType> streamIntervals;
 	private Instant streamStart;
+	private BridgeInstant streamStartBridge;
 
 	public CtsStreamType(){
 	}
@@ -66,4 +68,12 @@ public class CtsStreamType {
 	public void setStreamStart(Instant streamStart) {
 		this.streamStart = streamStart;
 	}
+
+	public void setStreamBridgeIntervalDuration(BridgeInterval streamBridgeIntervalDuration){
+		this.streamBridgeIntervalDuration = streamBridgeIntervalDuration;
+		this.streamIntervalDuration = streamBridgeIntervalDuration.asInterval();
+	}
+
+
+
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/EiQuoteType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/EiQuoteType.java
@@ -1,6 +1,8 @@
 package org.theenergymashuplab.cts;
 
 
+import java.time.Instant;
+
 /**
  * @author crossover
  * @version 1.0
@@ -25,6 +27,10 @@ public class EiQuoteType extends TenderBase {
 		this.quoteId = quoteId;
 		this.rfqId = rfqId;
 		this.tradeable = tradeable;
+	}
+
+	public EiQuoteType(Instant instant, SideType side, TenderDetail tenderDetail) {
+		super(instant, side, tenderDetail);
 	}
 
 	public MarketQuoteIdType getMarketQuoteId(){
@@ -68,12 +74,13 @@ public class EiQuoteType extends TenderBase {
 	}
 
 	@Override
-	public String toString(){
-		return "EiQuoteType [" +
-				"marketQuoteId=" + this.marketQuoteId.toString() +
-				"privateQuote=" + this.privateQuote +
-				"quoteId=" + this.quoteId.toString() +
-				"rfqId=" + this.rfqId.toString() +
-				"tradeable=" + this.tradeable + "]";
+	public String toString() {
+		return "EiQuoteType{" +
+				"marketQuoteId=" + marketQuoteId +
+				", privateQuote=" + privateQuote +
+				", quoteId=" + quoteId +
+				", rfqId=" + rfqId +
+				", tradeable=" + tradeable +
+				'}';
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/EiQuoteType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/EiQuoteType.java
@@ -8,20 +8,19 @@ import java.time.Instant;
  * @version 1.0
  * @created 28-Sep-2024 8:41:40 PM
  */
-public class EiQuoteType extends TenderBase {
+public class EiQuoteType extends QuoteBase {
 
 	public MarketQuoteIdType marketQuoteId;
 	public boolean privateQuote;
-	public TenderIdType quoteId;
+	public QuoteIdType quoteId = new QuoteIdType();
 	public RfqIdType rfqId;
 	public boolean tradeable;
-
 
 	public EiQuoteType(){
 
 	}
 
-	public EiQuoteType(MarketQuoteIdType marketQuoteId, boolean privateQuote, TenderIdType quoteId, RfqIdType rfqId, boolean tradeable){
+	public EiQuoteType(MarketQuoteIdType marketQuoteId, boolean privateQuote, QuoteIdType quoteId, RfqIdType rfqId, boolean tradeable){
 		this.marketQuoteId = marketQuoteId;
 		this.privateQuote = privateQuote;
 		this.quoteId = quoteId;
@@ -29,8 +28,8 @@ public class EiQuoteType extends TenderBase {
 		this.tradeable = tradeable;
 	}
 
-	public EiQuoteType(Instant instant, SideType side, TenderDetail tenderDetail) {
-		super(instant, side, tenderDetail);
+	public EiQuoteType(Instant instant, SideType side, QuoteDetail quoteDetail) {
+		super(instant, side, quoteDetail);
 	}
 
 	public MarketQuoteIdType getMarketQuoteId(){
@@ -49,11 +48,11 @@ public class EiQuoteType extends TenderBase {
 		this.privateQuote = privateQuote;
 	}
 
-	public TenderIdType getQuoteId(){
+	public QuoteIdType getQuoteId(){
 		return this.quoteId;
 	}
 
-	public void setQuoteId(TenderIdType quoteId){
+	public void setQuoteId(QuoteIdType quoteId){
 		this.quoteId = quoteId;
 	}
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/EiTenderType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/EiTenderType.java
@@ -35,6 +35,7 @@ public class EiTenderType extends TenderBase {
 		marketOrderId.setMyUidId(EMPTY_MARKET_ORDER_ID);
 	}
 	
+	//Already have constructor that could be used with streams
 	public EiTenderType(Instant expirationTime, SideType side, TenderDetail tenderDetail) {
 		super(expirationTime, side, tenderDetail);
 		marketOrderId.setMyUidId(EMPTY_MARKET_ORDER_ID);

--- a/complete/src/main/java/org/theenergymashuplab/cts/InstantType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/InstantType.java
@@ -28,7 +28,7 @@ public class InstantType {
 	}
 
 	public void setTime(String time) {
-		this.time = time;
+			this.time = time;
 	}
 
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/QuoteBase.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/QuoteBase.java
@@ -1,0 +1,125 @@
+package org.theenergymashuplab.cts;
+
+import java.time.Instant;
+import java.util.List;
+
+public abstract class QuoteBase {
+    private boolean allOrNone = false;  // TODO Added due to being a part of the March 2024 spec. All or none behavior has not be implemented yet
+    private String executionInstructions = "";  // TODO Added due to being a part of the March 2024 spec. execution instruction behavior has not be implemented yet
+    private Instant expirationTime = null;
+    private MarketIdType marketId = new MarketIdType();  // TODO Added due to being a part of the March 2024 spec. eml-cts can only handle one market at the moment
+    private int priceScale = 1;  // TODO Added due to being a part of the March 2024 spec. Variable price scales have not been implemented, so its always assumed to be 1 at the moment
+    private int quantityScale = 1;  // TODO Added due to being a part of the March 2024 spec. Variable quantity scales have not been implemented, so its always assumed to be 1 at the moment
+    private ResourceDesignatorType resourceDesignator = ResourceDesignatorType.ENERGY;
+    private SideType side;
+    private QuoteDetail quoteDetail; //If we have a stream type, this will be set to QuoteStreamDetail
+    private List<Integer> warrants = null;  // TODO Added due to being a part of the March 2024 spec. warrant behavior has not be implemented yet
+    private WarrantIdType warrantsList;
+
+    // Default constructor for EiRfqType and EiQuoteType
+    public QuoteBase(){
+
+    }
+
+    public QuoteBase(Instant expirationTime, SideType side, QuoteDetail quoteDetail) {
+        this.expirationTime = expirationTime;
+        this.side = side;
+        this.quoteDetail = quoteDetail;
+    }
+
+    public QuoteBase(boolean allOrNone, String executionInstructions, Instant expirationTime, MarketIdType marketId,
+                      int priceScale, int quantityScale, ResourceDesignatorType resourceDesignator, SideType side,
+                      QuoteDetail quoteDetail, List<Integer> warrants) {
+        this.allOrNone = allOrNone;
+        this.executionInstructions = executionInstructions;
+        this.expirationTime = expirationTime;
+        this.marketId = marketId;
+        this.priceScale = priceScale;
+        this.quantityScale = quantityScale;
+        this.resourceDesignator = resourceDesignator;
+        this.side = side;
+        this.quoteDetail = quoteDetail;
+        this.warrants = warrants;
+    }
+
+    public boolean isAllOrNone() {
+        return allOrNone;
+    }
+
+    public void setAllOrNone(boolean allOrNone) {
+        this.allOrNone = allOrNone;
+    }
+
+    public String getExecutionInstructions() {
+        return executionInstructions;
+    }
+
+    public void setExecutionInstructions(String executionInstructions) {
+        this.executionInstructions = executionInstructions;
+    }
+
+    public Instant getExpirationTime() {
+        return expirationTime;
+    }
+
+    public void setExpirationTime(Instant expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    public MarketIdType getMarketId() {
+        return marketId;
+    }
+
+    public void setMarketId(MarketIdType marketId) {
+        this.marketId = marketId;
+    }
+
+    public int getPriceScale() {
+        return priceScale;
+    }
+
+    public void setPriceScale(int priceScale) {
+        this.priceScale = priceScale;
+    }
+
+    public int getQuantityScale() {
+        return quantityScale;
+    }
+
+    public void setQuantityScale(int quantityScale) {
+        this.quantityScale = quantityScale;
+    }
+
+    public ResourceDesignatorType getResourceDesignator() {
+        return resourceDesignator;
+    }
+
+    public void setResourceDesignator(ResourceDesignatorType resourceDesignator) {
+        this.resourceDesignator = resourceDesignator;
+    }
+
+    public SideType getSide() {
+        return side;
+    }
+
+    public void setSide(SideType side) {
+        this.side = side;
+    }
+
+    public QuoteDetail getQuoteDetail() {
+        return quoteDetail;
+    }
+
+    public void setQuoteDetail(QuoteDetail QuoteDetail) {
+        this.quoteDetail = quoteDetail;
+    }
+
+    public List<Integer> getWarrants() {
+        return warrants;
+    }
+
+    public void setWarrants(List<Integer> warrants) {
+        this.warrants = warrants;
+    }
+}
+

--- a/complete/src/main/java/org/theenergymashuplab/cts/QuoteBase.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/QuoteBase.java
@@ -110,7 +110,7 @@ public abstract class QuoteBase {
         return quoteDetail;
     }
 
-    public void setQuoteDetail(QuoteDetail QuoteDetail) {
+    public void setQuoteDetail(QuoteDetail quoteDetail) {
         this.quoteDetail = quoteDetail;
     }
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/QuoteDetail.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/QuoteDetail.java
@@ -1,0 +1,26 @@
+package org.theenergymashuplab.cts;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/* The UML spec assumes that the implementing language can create and use
+ * C-style unions, which Java is incapable of implementing. Thus,
+ * the implementation of TenderDetail and its child classes are currently unstable until we
+ * can find a way to rectify the gap between the UML spec and Java's
+ * capabilities somehow */
+
+/* @JsonTypeInfo is needed to ensure that Jackson can deserialize TenderDetail
+ * TenderDetail is an abstract class, so Jackson needs to include type info in the
+ * JSON serialization to ensure that it will be able to correctly deserialize it to the
+ * correct concrete class (either TenderIntervalDetail or TenderStreamDetail (which has not been added yet))
+ *
+ *  You can learn more about it from the official Jackson Wiki (https://github.com/FasterXML/jackson-docs/wiki/JacksonPolymorphicDeserialization#12-per-class-annotations)
+ *  As well as from here: https://www.baeldung.com/jackson-inheritance */
+@JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = QuoteIntervalDetail.class, name = "interval"),  // TODO Once QuoteStreamInterval has been added, add its type here
+        @JsonSubTypes.Type(value = QuoteStreamDetail.class, name = "stream") //Added type for JSON
+})
+public abstract class QuoteDetail {
+
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/QuoteIdType.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/QuoteIdType.java
@@ -1,0 +1,19 @@
+package org.theenergymashuplab.cts;
+
+public class QuoteIdType extends UidType {
+
+    public long value() {
+        return this.myUidId;
+    }
+
+    public QuoteIdType()	{
+    }
+
+    @Override
+    public String toString()	{
+        return String.valueOf(myUidId);
+    }
+
+    // NEED SETTERS AND GETTERS FOR JSON SERIALIZATION?
+
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/QuoteIntervalDetail.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/QuoteIntervalDetail.java
@@ -1,0 +1,42 @@
+package org.theenergymashuplab.cts;
+
+public class QuoteIntervalDetail extends QuoteDetail {
+    private Interval interval;
+    private long price;
+    private long quantity;
+
+    public QuoteIntervalDetail(Interval interval, long price, long quantity) {
+        this.interval = interval;
+        this.price = price;
+        this.quantity = quantity;
+    }
+
+    public Interval getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Interval interval) {
+        this.interval = interval;
+    }
+
+    public long getPrice() {
+        return price;
+    }
+
+    public void setPrice(long price) {
+        this.price = price;
+    }
+
+    public long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(long quantity) {
+        this.quantity = quantity;
+    }
+
+    @Override
+    public String toString() {
+        return "QuoteIntervalDetail [interval=" + interval + ", price=" + price + ", quantity=" + quantity + "]";
+    }
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/QuoteStreamDetail.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/QuoteStreamDetail.java
@@ -1,0 +1,48 @@
+package org.theenergymashuplab.cts;
+
+public class QuoteStreamDetail extends QuoteDetail {
+
+    public CtsStreamType stream;
+    private BridgeInstant streamStart;
+    private long intervalDurationInMinutes;
+
+    public QuoteStreamDetail(){
+    }
+
+    public QuoteStreamDetail(CtsStreamType stream) {
+        this.stream = stream;
+    }
+
+    public CtsStreamType getStream() {
+        return stream;
+    }
+
+    public void setStream(CtsStreamType stream) {
+        this.stream = stream;
+    }
+
+    public BridgeInstant getStreamStart(){
+        return this.streamStart;
+    }
+
+    public void setStreamStart(BridgeInstant streamStart){
+        this.streamStart = streamStart;
+    }
+
+    public long getIntervalDurationInMinutes(){
+        return this.intervalDurationInMinutes;
+    }
+
+    public void setIntervalDurationInMinutes(long intervalDurationInMinutes){
+        this.intervalDurationInMinutes = intervalDurationInMinutes;
+    }
+
+    @Override
+    public String toString() {
+        return "QuoteStreamDetail{" +
+                "stream=" + stream+
+                //"streamStart=" + streamStart.toString() +
+                "intervalDurationInMinutes=" + intervalDurationInMinutes +
+                "}";
+    }
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/TenderBase.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/TenderBase.java
@@ -12,7 +12,7 @@ public abstract class TenderBase {
 	private int quantityScale = 1;  // TODO Added due to being a part of the March 2024 spec. Variable quantity scales have not been implemented, so its always assumed to be 1 at the moment
 	private ResourceDesignatorType resourceDesignator = ResourceDesignatorType.ENERGY;
 	private SideType side;
-	private TenderDetail tenderDetail;
+	private TenderDetail tenderDetail; //If we have a stream type, this will be set to TenderStreamDetail
 	private List<Integer> warrants = null;  // TODO Added due to being a part of the March 2024 spec. warrant behavior has not be implemented yet
 	private WarrantIdType warrantsList;
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/TenderDetail.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/TenderDetail.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  *  As well as from here: https://www.baeldung.com/jackson-inheritance */
 @JsonTypeInfo(use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="type")
 @JsonSubTypes({
-    @Type(value = TenderIntervalDetail.class, name = "interval")  // TODO Once TenderStreamInterval has been added, add its type here
+    @Type(value = TenderIntervalDetail.class, name = "interval"),  // TODO Once TenderStreamInterval has been added, add its type here
+	@Type(value = TenderStreamDetail.class, name = "stream") //Added type for JSON
 })
 public abstract class TenderDetail {
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/TenderStreamDetail.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/TenderStreamDetail.java
@@ -14,6 +14,10 @@ public class TenderStreamDetail extends TenderDetail {
 
 	}
 
+	public TenderStreamDetail(CtsStreamType stream) {
+		this.stream = stream;
+	}
+
 	public CtsStreamType getStream() {
 		return stream;
 	}
@@ -22,14 +26,10 @@ public class TenderStreamDetail extends TenderDetail {
 		this.stream = stream;
 	}
 
-	public TenderStreamDetail(CtsStreamType stream) {
-		this.stream = stream;
-	}
-
 	@Override
 	public String toString() {
 		return "TenderStreamDetail{" +
 				"stream=" + stream +
-				'}';
+				"}";
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/TenderStreamDetail.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/TenderStreamDetail.java
@@ -9,9 +9,10 @@ package org.theenergymashuplab.cts;
 public class TenderStreamDetail extends TenderDetail {
 
 	public CtsStreamType stream;
+	private BridgeInstant streamStart;
+	private long intervalDurationInMinutes;
 
 	public TenderStreamDetail(){
-
 	}
 
 	public TenderStreamDetail(CtsStreamType stream) {
@@ -26,10 +27,28 @@ public class TenderStreamDetail extends TenderDetail {
 		this.stream = stream;
 	}
 
+	public BridgeInstant getStreamStart(){
+		return this.streamStart;
+	}
+
+	public void setStreamStart(BridgeInstant streamStart){
+		this.streamStart = streamStart;
+	}
+
+	public long getIntervalDurationInMinutes(){
+		return this.intervalDurationInMinutes;
+	}
+
+	public void setIntervalDurationInMinutes(long intervalDurationInMinutes){
+		this.intervalDurationInMinutes = intervalDurationInMinutes;
+	}
+
 	@Override
 	public String toString() {
 		return "TenderStreamDetail{" +
-				"stream=" + stream +
+				"stream=" + stream.toString() +
+				//"streamStart=" + streamStart.toString() +
+				"intervalDurationInMinutes=" + intervalDurationInMinutes +
 				"}";
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/LmaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/LmaRestController.java
@@ -31,15 +31,7 @@ import org.apache.logging.log4j.Logger;
 // For RestTemplate
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
-import org.theenergymashuplab.cts.controller.payloads.EICanceledTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCancelTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreateStreamTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreateTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreateTransactionPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreatedStreamTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreatedTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreatedTransactionPayload;
-import org.theenergymashuplab.cts.controller.payloads.PositionAddPayload;
+import org.theenergymashuplab.cts.controller.payloads.*;
 import org.theenergymashuplab.cts.TenderIdType;
 import org.theenergymashuplab.cts.TenderIntervalDetail;
 import org.theenergymashuplab.cts.SideType;
@@ -312,7 +304,40 @@ public class LmaRestController {
 		//Return the response
 		return tempEiCreatedStreamTender;
 	}
-	
+
+	@PostMapping("/createStreamQuote")
+	public EiCreatedStreamQuotePayload postEiCreateStreamQuote(
+			@RequestBody EiCreateStreamQuotePayload eiCreateStreamQuote){
+
+		EiCreateStreamQuotePayload tempEiCreateStreamQuote;
+		EiCreatedStreamQuotePayload tempEiCreatedStreamQuote;
+
+		//Initialize the builder
+		final RestTemplateBuilder builder = new RestTemplateBuilder();
+		RestTemplate restTemplate;	// scope is method postEiCreateStreamTender
+		restTemplate = builder.build();
+
+		//Deserialize what was posted to us
+		tempEiCreateStreamQuote = eiCreateStreamQuote;
+
+		System.out.println("tempEiCreateStreamQuote before passing to lme"+ tempEiCreateStreamQuote.toString());
+
+//		Log it
+		logger.debug("postEiCreateStreamTender to LME. TenderId " +
+				tempEiCreateStreamQuote.getQuote().getQuoteId().toString());
+		/*
+		 * Pass on to LME and use POST responseBody in reply to origin
+		 */
+		tempEiCreatedStreamQuote = restTemplate.postForObject("http://localhost:8080/lme/createStreamQuote",
+				tempEiCreateStreamQuote,
+				EiCreatedStreamQuotePayload.class);
+
+		//Log it
+		logger.trace("LMA after forward to LME and before return " + tempEiCreatedStreamQuote.toString());
+
+		//Return the response
+		return tempEiCreatedStreamQuote;
+	}
 
 	public static EiTenderType getCurrentTender() {
 		return currentTender;

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/LmaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/LmaRestController.java
@@ -320,9 +320,7 @@ public class LmaRestController {
 		//Deserialize what was posted to us
 		tempEiCreateStreamQuote = eiCreateStreamQuote;
 
-		System.out.println("tempEiCreateStreamQuote before passing to lme"+ tempEiCreateStreamQuote.toString());
-
-//		Log it
+		//Log it
 		logger.debug("postEiCreateStreamTender to LME. TenderId " +
 				tempEiCreateStreamQuote.getQuote().getQuoteId().toString());
 		/*

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/LmaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/LmaRestController.java
@@ -33,8 +33,10 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.RestTemplate;
 import org.theenergymashuplab.cts.controller.payloads.EICanceledTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCancelTenderPayload;
+import org.theenergymashuplab.cts.controller.payloads.EiCreateStreamTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreateTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreateTransactionPayload;
+import org.theenergymashuplab.cts.controller.payloads.EiCreatedStreamTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreatedTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreatedTransactionPayload;
 import org.theenergymashuplab.cts.controller.payloads.PositionAddPayload;
@@ -278,6 +280,39 @@ public class LmaRestController {
 		
 		return tempPostResponse;
 	}
+
+	@PostMapping("/createStreamTender")
+	public EiCreatedStreamTenderPayload postEiCreateStreamTender(
+		@RequestBody EiCreateStreamTenderPayload eiCreateStreamTender){
+
+		EiCreateStreamTenderPayload tempEiCreateStreamTender;
+		EiCreatedStreamTenderPayload tempEiCreatedStreamTender;
+
+		//Initialize the builder
+		final RestTemplateBuilder builder = new RestTemplateBuilder();
+		RestTemplate restTemplate;	// scope is method postEiCreateStreamTender	
+    	restTemplate = builder.build();
+
+		//Deserialize what was posted to us
+		tempEiCreateStreamTender = eiCreateStreamTender;
+
+		//Log it
+		logger.debug("postEiCreateStreamTender to LME. TenderId " +
+				tempEiCreateStreamTender.getTender().getTenderId().toString());
+		/*
+		 * Pass on to LME and use POST responseBody in reply to origin
+		 */
+		tempEiCreatedStreamTender = restTemplate.postForObject("http://localhost:8080/lme/createStreamTender", 
+				tempEiCreateStreamTender,
+				EiCreatedStreamTenderPayload.class);
+		
+		//Log it
+		logger.trace("LMA after forward to LME and before return " + tempEiCreatedStreamTender.toString());
+
+		//Return the response
+		return tempEiCreatedStreamTender;
+	}
+	
 
 	public static EiTenderType getCurrentTender() {
 		return currentTender;

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/LmeRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/LmeRestController.java
@@ -33,8 +33,10 @@ import org.theenergymashuplab.cts.MarketOrderIdType;
 import org.theenergymashuplab.cts.TenderIdType;
 import org.theenergymashuplab.cts.controller.payloads.EICanceledTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCancelTenderPayload;
+import org.theenergymashuplab.cts.controller.payloads.EiCreateStreamTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreateTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreateTransactionPayload;
+import org.theenergymashuplab.cts.controller.payloads.EiCreatedStreamTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.EiCreatedTenderPayload;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -182,6 +184,20 @@ public class LmeRestController {
 				tempCreate.getRequestId());
 		
 		return tempCreated;
+	}
+
+	@PostMapping("/createStreamTender")
+	public EiCreatedStreamTenderPayload postEiCreateStreamTender(
+		@RequestBody EiCreateStreamTenderPayload eiCreateStreamTenderPayload){
+
+		EiTenderType tempTender;
+		EiCreateStreamTenderPayload createStreamTenderPayload;
+		Boolean addQSuccess = false;
+
+
+
+		return null;
+
 	}
 	
 	

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/LmeRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/LmeRestController.java
@@ -328,12 +328,8 @@ public class LmeRestController {
 		//Deserialize from the request
 		tempCreateStreamQuotePayload = eiCreateStreamQuotePayload;
 
-
-		System.out.println("tempCreateStreamQuotePayload in lme "+tempCreateStreamQuotePayload.toString());
-
-
 		//Grab the stream for us to use
-		quoteStreamDetail = (QuoteStreamDetail) tempCreateStreamQuotePayload.getQuote().getQuoteDetail();
+		quoteStreamDetail = (QuoteStreamDetail)tempCreateStreamQuotePayload.getQuote().getQuoteDetail();
 
 		stream = quoteStreamDetail.getStream();
 		partyID = tempCreateStreamQuotePayload.getPartyId();
@@ -377,9 +373,9 @@ public class LmeRestController {
 			tempCreate.setPartyId(partyID);
 			tempCreate.setCounterPartyId(counterPartyID);
 
-			addQSuccess = queueQuoteFromLme.add(tempCreate);
-			logger.debug("queueQuoteFromLme addQsuccess " + addQSuccess +
-					" QuoteId " + tempQuote.getQuoteId());
+		//	addQSuccess = queueQuoteFromLme.add(tempCreate);
+		//	logger.debug("queueQuoteFromLme addQsuccess " + addQSuccess +
+		//			" QuoteId " + tempQuote.getQuoteId());
 
 			//Grab the Quote ID and store
 			createdQuotes.add(tempQuote.getQuoteId().value());
@@ -392,7 +388,7 @@ public class LmeRestController {
 		/* ================================================================ */
 
 		response.setPartyId(partyID);
-		response.setResponse(new EiResponse(200, "OK"));
+		response.setResponse(new EiResponse(210, "NOT YET IMPLEMENTED"));
 		response.setCounterPartyId(counterPartyID);
 		response.setCreatedQuotes(createdQuotes);
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -36,17 +36,7 @@ import org.theenergymashuplab.cts.TenderIdType;
 import org.theenergymashuplab.cts.TenderIntervalDetail;
 import org.theenergymashuplab.cts.TenderStreamDetail;
 import org.theenergymashuplab.cts.TransactionIdType;
-import org.theenergymashuplab.cts.controller.payloads.ClientCreateStreamTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.ClientCreateTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.ClientCreateTransactionPayload;
-import org.theenergymashuplab.cts.controller.payloads.ClientCreatedTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.ClientCreatedTransactionPayload;
-import org.theenergymashuplab.cts.controller.payloads.EICanceledTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCancelTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreateTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreateTransactionPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreatedTenderPayload;
-import org.theenergymashuplab.cts.controller.payloads.EiCreatedTransactionPayload;
+import org.theenergymashuplab.cts.controller.payloads.*;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -394,7 +384,8 @@ public class TeuaRestController {
 			@PathVariable String teuaId,
 			@RequestBody ClientCreateStreamTenderPayload clientCreateStreamTender)	{
 
-		ClientCreateStreamTenderPayload tempClientCreateStreamTender;	
+		ClientCreateStreamTenderPayload tempClientCreateStreamTender;
+		ClientCreatedStreamTenderPayload tempReturn;
 		CtsStreamType stream;
 		EiTenderType tender;
 		//TODO may change this here

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -24,7 +24,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.theenergymashuplab.cts.ActorIdType;
+import org.theenergymashuplab.cts.BridgeInterval;
 import org.theenergymashuplab.cts.CancelReasonType;
+import org.theenergymashuplab.cts.CtsStreamType;
 import org.theenergymashuplab.cts.EiCanceledResponseType;
 import org.theenergymashuplab.cts.EiResponse;
 import org.theenergymashuplab.cts.EiTenderType;
@@ -50,6 +52,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.LogManager;
@@ -392,8 +395,56 @@ public class TeuaRestController {
 			@PathVariable String teuaId,
 			@RequestBody ClientCreateStreamTenderPayload clientCreateStreamTender)	{
 
-			return null;
-			
+		ClientCreateStreamTenderPayload tempClientCreateStreamTender;	
+		ClientCreatedStreamTenderPayload tempReturn;
+		CtsStreamType stream;
+		EiTenderType tender;
+		//TODO may change this here
+		EiCreateTenderPayload eiCreateTender;	
+		Integer numericTeuaId = -1;
+		String positionUri;
+		
+		final RestTemplateBuilder builder = new RestTemplateBuilder();
+		// scope is function postEiCreateTender
+		RestTemplate restTemplate = builder.build();
+				
+		if (lmePartyId == null)	{
+			// builder = new RestTemplateBuilder();
+			restTemplate = builder.build();
+			lmePartyId = restTemplate.getForObject(
+					"http://localhost:8080/lme/party",
+					ActorIdType.class);
+		}
+		
+		numericTeuaId = Integer.valueOf(teuaId);
+		
+		
+		//convert to URI for position manager
+		positionUri = "/position/" 
+				 + actorIds[numericTeuaId] +
+				"/getPosition";
+		logger.debug("positionUri is " + positionUri);
+		
+		logger.debug("numericTeuaId is " + numericTeuaId +" String is " + teuaId);		
+		logger.debug("postEiCreateTender teuaId " +
+			teuaId +
+			" actorNumericIds[teuaId] " +
+			actorIds[numericTeuaId].toString());
+		
+		//Call the serializer
+		tempClientCreateStreamTender = clientCreateStreamTender;	// save the parameter
 
+		TenderDetail tenderDetail;
+		//Construct the bridge interval
+		BridgeInterval startInterval = new BridgeInterval(clientCreateStreamTender.getIntervalDurationInMinutes(), clientCreateStreamTender.getStreamStart().asInstant());
+
+		stream = new CtsStreamType(startInterval.asInterval(),
+								clientCreateStreamTender.getStreamIntervals(), 
+								clientCreateStreamTender.getStreamStart().asInstant());
+
+		tenderDetail = new TenderStreamDetail(stream);
+	
+		//TODO FIXME
+		return null;
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -327,6 +327,7 @@ public class TeuaRestController {
 			actorIds[numericTeuaId].toString());
 		
 		tempClientCreateTender = clientCreateTender;	// save the parameter
+														
 
 		/*
 		 * Create a new EiTender using the interval, quantity, price,and expiration
@@ -339,12 +340,18 @@ public class TeuaRestController {
 		 * if Building sends to /teua/7 that means it's client 7
 		 */
 		
-		// TODO Currently not up to the March 2024 standard: This will need to be changed when clients become capable of sending stream tenders - @FIXME Omkar 
-		TenderDetail tenderDetail = new TenderIntervalDetail(
+		// TODO Currently not up to the March 2024 standard: This will need to be changed when clients become capable of sending stream tenders 
+		// So this will be changed based on what kind of tender we have. If we have an interval tender, then this is fine, but if we have a stream tender, 
+		// we'll need to update the construction of tender detail
+		TenderDetail tenderDetail = null;
+		if(tempClientCreateTender.getBridgeInterval() != null){
+			 tenderDetail = new TenderIntervalDetail(
 				tempClientCreateTender.getInterval(),
 				tempClientCreateTender.getPrice(),
 				tempClientCreateTender.getQuantity()
-		);
+			);
+		}
+
 		tender = new EiTenderType(
 				tempClientCreateTender.getBridgeExpireTime().asInstant(),
 				tempClientCreateTender.getSide(),

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -427,7 +427,10 @@ public class TeuaRestController {
 								tempClientCreateStreamTender.getStreamStart().asInstant());
 
 		//Create a new tender stream detail
-		TenderDetail tenderDetail = new TenderStreamDetail(stream);
+		TenderStreamDetail tenderDetail = new TenderStreamDetail(stream);
+		//Save this for later
+		tenderDetail.setIntervalDurationInMinutes(clientCreateStreamTender.getIntervalDurationInMinutes());
+		
 
 		//Construct the stream tender object for us to send to LMA
 		tender = new EiTenderType(tempClientCreateStreamTender.getBridgeExpireTime().asInstant(), tempClientCreateStreamTender.getSide(), tenderDetail);
@@ -438,7 +441,6 @@ public class TeuaRestController {
 		eiCreateStreamTender.setPartyId(actorIds[numericTeuaId]);
 		eiCreateStreamTender.setCounterPartyId(lmePartyId);
 		
-
 		//	And forward to the LMA
 		restTemplate = builder.build();
 		EiCreatedStreamTenderPayload result = restTemplate.postForObject
@@ -448,76 +450,12 @@ public class TeuaRestController {
 		/* Done creating stream tender */
 
 		// and put CtsTenderId in ClientCreatedTenderPayload
-		tempReturn = new ClientCreatedStreamTenderPayload(result.getTenderId().value());
 		logger.trace("TEUA before return ClientCreatedTender to Client/SC " +
-				tempReturn.toString());
+				result.toString());
 		
 		return result;
-
-
-/*
-
-		//We will keep track of what the current start interval is
-		BridgeInterval currentStartInterval = startInterval;
-		BridgeInstant currentStartInstant = new BridgeInstant();
-
-
-		//Keep track of all of the created tenders
-		List<EiCreatedTenderPayload> createdTenders = new ArrayList<>();
-
-*/
-		/**
-		 * Design of this component:
-		 * 	In the CTS market, stream tenders do not exist. They are simply a client-side semantic that allows clients to construct a stream tender
-		 * 	specifying a stream of resource purchases or sales. Stream tenders themselves are just a sequence of separate tenders with
-		 * 	different prices and quantities, arranged in sequential intervals of the same length. So, we can leverage the existing
-		 * 	architecture around creating tenders to generate a sequence of createTender requests according to the prices and intervals
-		 * 	outlined in the stream tender object. This may later be changed with the implementation of "allOrNone", but currently, it serves our
-		 * 	purposes
-		 */
-		/*
-		for(CtsStreamIntervalType interval : stream.getStreamIntervals()){
-			//Create the individual Tender Interval payload
-			tenderDetail = new TenderIntervalDetail(currentStartInterval.asInterval(), interval.getStreamIntervalPrice(), interval.getStreamIntervalQuantity());
-
-			//Advance the interval by however many minutes we specify
-			currentStartInstant.setInstant(currentStartInterval.getDtStart().asInstant().plusSeconds(tempClientCreateStreamTender.getIntervalDurationInMinutes()*60));
-			//Set the current start interval
-			currentStartInterval.setDtStart(currentStartInstant);
-			//Create the new individual interval tender
-			tender = new EiTenderType(clientCreateStreamTender.getBridgeExpireTime().asInstant(), clientCreateStreamTender.getSide(), tenderDetail);
-			
-			// 	Construct the EiCreateTender payload to be forwarded to LMA
-		//	eiCreateTender = new EiCreateTenderPayload(tender, actorIds[numericTeuaId],
-//						this.lmePartyId);
-
-			// set party and counterParty -partyId saved in actorIds, counterParty is lmePartyId
-//			eiCreateTender.setPartyId(actorIds[numericTeuaId]);
-//			eiCreateTender.setCounterPartyId(lmePartyId);
-		
-//			logger.trace("Stream Tender Creation Sequence: TEUA sending EiCreateTender to LMA " +
-//					eiCreateTender.toString());
-			
-			//	And forward to the LMA
-			restTemplate = builder.build();
-			// Save this to the 
-//			createdTenders.add(
-//				restTemplate.postForObject("http://localhost:8080/lma/createTender", 
-//											eiCreateTender,
-//											EiCreatedTenderPayload.class)
-//			);
-		}
-
-		//Make a new return value with the created tenders
-		tempReturn = new ClientCreatedStreamTenderPayload(createdTenders);
-		//Log it
-		logger.trace("Stream Tender Creation Sequence: TEUA before return ClientCreatedTender to Client/SC " +
-				tempReturn.toString());
-
-		//Give this back so we'll see it in postman
-		return tempReturn;
-*/
 	}
+
 
 	@PostMapping("/{teuaId}/clientCreateStreamQuote")
 	public ClientCreatedStreamQuotePayload postClientCreateStreamQuote(

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -34,6 +34,8 @@ import org.theenergymashuplab.cts.TenderIdType;
 import org.theenergymashuplab.cts.TenderIntervalDetail;
 import org.theenergymashuplab.cts.TenderStreamDetail;
 import org.theenergymashuplab.cts.TransactionIdType;
+import org.theenergymashuplab.cts.controller.payloads.ClientCreateStreamTenderPayload;
+import org.theenergymashuplab.cts.controller.payloads.ClientCreatedStreamTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.ClientCreateTenderPayload;
 import org.theenergymashuplab.cts.controller.payloads.ClientCreateTransactionPayload;
 import org.theenergymashuplab.cts.controller.payloads.ClientCreatedTenderPayload;
@@ -385,4 +387,13 @@ public class TeuaRestController {
 		return result;
 	}
 	
+	@PostMapping("{teuaId}/clientCreateStreamTender")
+	public EiCreatedTenderPayload postClientCreateStreamTender(
+			@PathVariable String teuaId,
+			@RequestBody ClientCreateStreamTenderPayload clientCreateStreamTender)	{
+
+			return null;
+			
+
+	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -339,7 +339,7 @@ public class TeuaRestController {
 		 * if Building sends to /teua/7 that means it's client 7
 		 */
 		
-		// TODO Currently not up to the March 2024 standard: This will need to be changed when clients become capable of sending stream tenders
+		// TODO Currently not up to the March 2024 standard: This will need to be changed when clients become capable of sending stream tenders - @FIXME Omkar 
 		TenderDetail tenderDetail = new TenderIntervalDetail(
 				tempClientCreateTender.getInterval(),
 				tempClientCreateTender.getPrice(),

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -376,7 +376,6 @@ public class TeuaRestController {
 			@RequestBody ClientCreateStreamTenderPayload clientCreateStreamTender)	{
 
 		ClientCreateStreamTenderPayload tempClientCreateStreamTender;
-		ClientCreatedStreamTenderPayload tempReturn;
 		CtsStreamType stream;
 		EiTenderType tender;
 		EiCreateStreamTenderPayload eiCreateStreamTender;
@@ -462,7 +461,6 @@ public class TeuaRestController {
 			@RequestBody ClientCreateStreamQuotePayload clientCreateStreamQuote)	{
 
 		ClientCreateStreamQuotePayload tempClientCreateStreamQuote;
-		ClientCreatedStreamQuotePayload tempReturn;
 		CtsStreamType stream;
 		EiQuoteType quote;
 		EiCreateStreamQuotePayload eiCreateStreamQuote;
@@ -503,6 +501,7 @@ public class TeuaRestController {
 
 		//Call the serializer
 		tempClientCreateStreamQuote = clientCreateStreamQuote;	// save the parameter
+		System.out.println(tempClientCreateStreamQuote.getStreamIntervals());
 
 		//Construct the start interval
 		BridgeInterval startInterval = new BridgeInterval(clientCreateStreamQuote.getIntervalDurationInMinutes(), clientCreateStreamQuote.getStreamStart().asInstant());
@@ -522,15 +521,13 @@ public class TeuaRestController {
 		//Construct the stream Quote object for us to send to LMA
 		quote = new EiQuoteType(tempClientCreateStreamQuote.getBridgeExpireTime().asInstant(), tempClientCreateStreamQuote.getSide(), quoteDetail);
 
-		System.out.println("Quote : "+ quote.toString());
-
 		//Construct the EiCreateStreamQuote payload to be forwarded to LMA
 		eiCreateStreamQuote = new EiCreateStreamQuotePayload(quote, actorIds[numericTeuaId], this.lmePartyId);
+
 		// set party and counterParty -partyId saved in actorIds, counterParty is lmePartyId
 		eiCreateStreamQuote.setPartyId(actorIds[numericTeuaId]);
 		eiCreateStreamQuote.setCounterPartyId(lmePartyId);
 
-		System.out.println("eiCreateStreamQuote value before post to lma"+eiCreateStreamQuote.toString());
 		//	And forward to the LMA
 		restTemplate = builder.build();
 		EiCreatedStreamQuotePayload result = restTemplate.postForObject

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -342,48 +342,18 @@ public class TeuaRestController {
 		 */
 		
 		// TODO Currently not up to the March 2024 standard: This will need to be changed when clients become capable of sending stream tenders 
-		// So this will be changed based on what kind of tender we have. If we have an interval tender, then this is fine, but if we have a stream tender, 
-		// we'll need to update the construction of tender detail
 		
-		//Just for the compiler to not warn us about noninitialization	
-		TenderDetail tenderDetail = null;
+		TenderDetail tenderDetail;
 
 
 		/*
-		 * Handling of Stream vs. Interval Tenders
-		 * 
-		 * Stream and Interval Tenders will both be POSTED with requests of type "clientCreateTenderPayload", so they will end
-		 * up here. In ClientCreateTenderPayload, the interval and ctsStream attributes are set to null by default. When the JSON
-		 * is serialized, the appropriate setters/getters will be called based on what is in the JSON
-		 *
-		 * Sample Interval Tender POST request:
-		 *
-		 *{"info":"ClientCreateTenderPayload",
-		 * 		"side":"SELL",
-		 * 		"quantity":54,
-		 * 		"price":190,
-		 * 		"ctsTenderId":0,
-		 * 		"bridgeInterval":{"durationInMinutes":60,"dtStart":{"instantString":"2020-06-20T05:00:00Z"}},
-		 * 		"bridgeExpireTime":{"instantString":"2020-06-20T16:00:00Z"}}
-		 * 
-		 * This request would be serialized and the bridgeInterval attribute would be set and therefore nonnull, so
-		 * we would encounter the first case and create an interval tender.
-		 *
-		 *
-		 * 
+		 * We assume that everything that is in here is an interval tender
 		 */
-		if(tempClientCreateTender.getBridgeInterval() != null){
-			 tenderDetail = new TenderIntervalDetail(
+		 tenderDetail = new TenderIntervalDetail(
 				tempClientCreateTender.getInterval(),
 				tempClientCreateTender.getPrice(),
 				tempClientCreateTender.getQuantity()
 			);
-		} else if (tempClientCreateTender.getCtsStream() != null){
-			tenderDetail = new TenderStreamDetail(tempClientCreateTender.getCtsStream());
-		} else {
-			//TODO May not be what we want -- temporary fix
-			logger.traceExit("ERROR: Invalid POST request");
-		}
 
 		tender = new EiTenderType(
 				tempClientCreateTender.getBridgeExpireTime().asInstant(),

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/TeuaRestController.java
@@ -392,7 +392,6 @@ public class TeuaRestController {
 		ClientCreatedStreamTenderPayload tempReturn;
 		CtsStreamType stream;
 		EiTenderType tender;
-		//TODO may change this here
 		EiCreateTenderPayload eiCreateTender;	
 		Integer numericTeuaId = -1;
 		String positionUri;
@@ -425,26 +424,24 @@ public class TeuaRestController {
 			" actorNumericIds[teuaId] " +
 			actorIds[numericTeuaId].toString());
 		
-		//Call the serializer
+		//Call the serializer 
 		tempClientCreateStreamTender = clientCreateStreamTender;	// save the parameter
-		ClientCreateStreamTenderPayload payload = null;
-
+		
 		//Construct the bridge interval
 		BridgeInterval startInterval = new BridgeInterval(clientCreateStreamTender.getIntervalDurationInMinutes(), clientCreateStreamTender.getStreamStart().asInstant());
 
 		//Create the new stream object
 		stream = new CtsStreamType(startInterval.asInterval(),
-								clientCreateStreamTender.getStreamIntervals(), 
-								clientCreateStreamTender.getStreamStart().asInstant());
+								tempClientCreateStreamTender.getStreamIntervals(), 
+								tempClientCreateStreamTender.getStreamStart().asInstant());
 
 		List<Long> createdTenders = new ArrayList<>();
 
 		//We will keep track of what the current start interval is
 		BridgeInterval currentStartInterval = startInterval;
 		TenderDetail tenderDetail;
-		//BridgeInstant currentStartInstant = new BridgeInstant();
+		BridgeInstant currentStartInstant = new BridgeInstant();
 
-		/*
 		//For each interval in stream intervals
 		for(CtsStreamIntervalType interval : stream.getStreamIntervals()){
 			//Create the individual Tender Interval payload
@@ -454,13 +451,13 @@ public class TeuaRestController {
 			currentStartInstant.setInstant(currentStartInterval.getDtStart().asInstant().plusSeconds(tempClientCreateStreamTender.getIntervalDurationInMinutes()*60));
 			//Set the current start interval
 			currentStartInterval.setDtStart(currentStartInstant);
-//Create the new individual interval tender
+			//Create the new individual interval tender
 			tender = new EiTenderType(clientCreateStreamTender.getBridgeExpireTime().asInstant(), clientCreateStreamTender.getSide(), tenderDetail);
-			
 			
 			// 	Construct the EiCreateTender payload to be forwarded to LMA
 			eiCreateTender = new EiCreateTenderPayload(tender, actorIds[numericTeuaId],
 						this.lmePartyId);
+
 			// set party and counterParty -partyId saved in actorIds, counterParty is lmePartyId
 			eiCreateTender.setPartyId(actorIds[numericTeuaId]);
 			eiCreateTender.setCounterPartyId(lmePartyId);
@@ -482,7 +479,6 @@ public class TeuaRestController {
 		logger.trace("TEUA before return ClientCreatedTender to Client/SC " +
 				tempReturn.toString());
 	
-		*/
 		//TODO FIXME
 		return null;
 	}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamQuotePayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamQuotePayload.java
@@ -1,0 +1,103 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+import org.theenergymashuplab.cts.BridgeInstant;
+import org.theenergymashuplab.cts.CtsStreamIntervalType;
+import org.theenergymashuplab.cts.SideType;
+
+import java.util.List;
+
+public class ClientCreateStreamQuotePayload {
+    private String info = "ClientCreateStreamQuotePayload";
+    // Side that we are on
+    private SideType side;
+    private long ctsQuoteId;
+    //A list of our streamIntervals
+    private List<CtsStreamIntervalType> streamIntervals;
+    private BridgeInstant streamStart;
+    private BridgeInstant bridgeExpireTime;
+    private long intervalDurationInMinutes;
+
+
+
+    public ClientCreateStreamQuotePayload() {
+    }
+
+    public ClientCreateStreamQuotePayload(String info, SideType side, long ctsQuoteId, List<CtsStreamIntervalType> streamIntervals, BridgeInstant streamStart, BridgeInstant bridgeExpireTime, long intervalDurationInMinutes) {
+        this.info = info;
+        this.side = side;
+        this.ctsQuoteId = ctsQuoteId;
+        this.streamIntervals = streamIntervals;
+        this.streamStart = streamStart;
+        this.bridgeExpireTime = bridgeExpireTime;
+        this.intervalDurationInMinutes = intervalDurationInMinutes;
+    }
+
+    public String getInfo() {
+        return info;
+    }
+
+    public void setInfo(String info) {
+        this.info = info;
+    }
+
+    public SideType getSide() {
+        return side;
+    }
+
+    public void setSide(SideType side) {
+        this.side = side;
+    }
+
+    public long getCtsQuoteId() {
+        return ctsQuoteId;
+    }
+
+    public void setCtsQuoteId(long ctsQuoteId) {
+        this.ctsQuoteId = ctsQuoteId;
+    }
+
+    public List<CtsStreamIntervalType> getStreamIntervals() {
+        return streamIntervals;
+    }
+
+    public void setStreamIntervals(List<CtsStreamIntervalType> streamIntervals) {
+        this.streamIntervals = streamIntervals;
+    }
+
+    public BridgeInstant getStreamStart() {
+        return streamStart;
+    }
+
+    public void setStreamStart(BridgeInstant streamStart) {
+        this.streamStart = streamStart;
+    }
+
+    public BridgeInstant getBridgeExpireTime() {
+        return bridgeExpireTime;
+    }
+
+    public void setBridgeExpireTime(BridgeInstant bridgeExpireTime) {
+        this.bridgeExpireTime = bridgeExpireTime;
+    }
+
+    public long getIntervalDurationInMinutes() {
+        return intervalDurationInMinutes;
+    }
+
+    public void setIntervalDurationInMinutes(long intervalDurationInMinutes) {
+        this.intervalDurationInMinutes = intervalDurationInMinutes;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientCreateStreamQuotePayload{" +
+                "info='" + info + '\'' +
+                ", side=" + side +
+                ", ctsQuoteId=" + ctsQuoteId +
+                ", streamIntervals=" + streamIntervals +
+                ", streamStart=" + streamStart +
+                ", bridgeExpireTime=" + bridgeExpireTime +
+                ", intervalDurationInMinutes=" + intervalDurationInMinutes +
+                '}';
+    }
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
@@ -1,0 +1,11 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+
+public class ClientCreateStreamTenderPayload{
+	private String info = "ClientCreateStreamTenderPayload";
+
+	//JSON
+	public ClientCreateStreamTenderPayload(){
+	}
+
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
@@ -20,7 +20,30 @@ public class ClientCreateStreamTenderPayload{
 	public ClientCreateStreamTenderPayload(){
 	}
 
-	public String getInfo() { 
+	public ClientCreateStreamTenderPayload(String info, SideType side, long ctsTenderId, List<CtsStreamIntervalType> streamIntervals, BridgeInstant streamStart, BridgeInstant bridgeExpireTime, long intervalDurationInMinutes) {
+		this.info = info;
+		this.side = side;
+		this.ctsTenderId = ctsTenderId;
+		this.streamIntervals = streamIntervals;
+		this.streamStart = streamStart;
+		this.bridgeExpireTime = bridgeExpireTime;
+		this.intervalDurationInMinutes = intervalDurationInMinutes;
+	}
+
+	@Override
+	public String toString() {
+		return "ClientCreateStreamTenderPayload{" +
+				"info='" + info + '\'' +
+				", side=" + side +
+				", ctsTenderId=" + ctsTenderId +
+				", streamIntervals=" + streamIntervals +
+				", streamStart=" + streamStart +
+				", bridgeExpireTime=" + bridgeExpireTime +
+				", intervalDurationInMinutes=" + intervalDurationInMinutes +
+				'}';
+	}
+
+	public String getInfo() {
 		return info;
 	}
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
@@ -3,6 +3,8 @@ package org.theenergymashuplab.cts.controller.payloads;
 import org.theenergymashuplab.cts.BridgeInstant;
 import org.theenergymashuplab.cts.CtsStreamIntervalType;
 import org.theenergymashuplab.cts.SideType;
+
+
 import java.util.List;
 
 public class ClientCreateStreamTenderPayload{
@@ -10,8 +12,10 @@ public class ClientCreateStreamTenderPayload{
 	// Side that we are on
 	private SideType side;
 	private long ctsTenderId;
+
 	//A list of our streamIntervals
 	private List<CtsStreamIntervalType> streamIntervals;
+
 	private BridgeInstant streamStart;
 	private BridgeInstant bridgeExpireTime;	
 	private long intervalDurationInMinutes;

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateStreamTenderPayload.java
@@ -1,11 +1,79 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
+import org.theenergymashuplab.cts.BridgeInstant;
+import org.theenergymashuplab.cts.CtsStreamIntervalType;
+import org.theenergymashuplab.cts.SideType;
+import java.util.List;
 
 public class ClientCreateStreamTenderPayload{
 	private String info = "ClientCreateStreamTenderPayload";
+	// Side that we are on
+	private SideType side;
+	private long ctsTenderId;
+	//A list of our streamIntervals
+	private List<CtsStreamIntervalType> streamIntervals;
+	private BridgeInstant streamStart;
+	private BridgeInstant bridgeExpireTime;	
+	private long intervalDurationInMinutes;
 
 	//JSON
 	public ClientCreateStreamTenderPayload(){
+	}
+
+	public String getInfo() { 
+		return info;
+	}
+
+	public void setInfo(String info) {
+		this.info = info;
+	}
+
+	public SideType getSide() {
+		return side;
+	}
+
+	public void setSide(SideType side) {
+		this.side = side;
+	}
+
+	public long getCtsTenderId() {
+		return ctsTenderId;
+	}
+
+	public void setCtsTenderId(long ctsTenderId) {
+		this.ctsTenderId = ctsTenderId;
+	}
+
+	public List<CtsStreamIntervalType> getStreamIntervals(){
+		return this.streamIntervals;
+	}
+
+	public void setStreamIntervals(List<CtsStreamIntervalType> streamIntervals){
+		this.streamIntervals = streamIntervals;
+	}
+
+	public BridgeInstant getStreamStart(){
+		return this.streamStart;
+	}
+
+	public void setStreamStart(BridgeInstant streamStart){
+		this.streamStart = streamStart;
+	}
+
+	public BridgeInstant getBridgeExpireTime(){
+		return this.bridgeExpireTime;
+	}
+
+	public void setBridgeExpireTime(BridgeInstant bridgeExpireTime){
+		this.bridgeExpireTime = bridgeExpireTime;
+	}
+
+	public long getIntervalDurationInMinutes(){
+		return this.intervalDurationInMinutes;
+	}
+	
+	public void setIntervalDurationInMinutes(long intervalDurationInMinutes){
+		this.intervalDurationInMinutes = intervalDurationInMinutes;
 	}
 
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
@@ -21,6 +21,7 @@ import java.time.*;
 
 import org.theenergymashuplab.cts.BridgeInstant;
 import org.theenergymashuplab.cts.BridgeInterval;
+import org.theenergymashuplab.cts.CtsStreamType;
 import org.theenergymashuplab.cts.Interval;
 import org.theenergymashuplab.cts.SideType;
 
@@ -30,8 +31,10 @@ public class ClientCreateTenderPayload {
 	private long quantity;
 	private long price;
 	private long ctsTenderId;
-	private BridgeInterval bridgeInterval;
-	private BridgeInstant bridgeExpireTime;	
+	//So that we can catch TODO
+	private BridgeInterval bridgeInterval = null;
+	private BridgeInstant bridgeExpireTime = null;	
+	private CtsStreamType ctsStream = null;
 //	private boolean ignorePosition; TODO 1.01	
 
 	// Uses BridgeInterval to avoid serialization issues
@@ -70,6 +73,9 @@ public class ClientCreateTenderPayload {
 		this.bridgeInterval = new BridgeInterval(60, dtStart);
 		this.bridgeExpireTime = new BridgeInstant(expire);
 	}
+
+	// Constructor takes stream description
+	//May need new constructor
 	
 	@Override
 	public String toString()	{
@@ -143,6 +149,14 @@ public class ClientCreateTenderPayload {
 
 	public void setBridgeExpireTime(BridgeInstant bridgeExpireTime) {
 		this.bridgeExpireTime = bridgeExpireTime;
+	}
+
+	public CtsStreamType getCtsStream(){
+		return this.ctsStream;
+	}
+
+	public void setCtsStream(CtsStreamType ctsStream){
+		this.ctsStream = ctsStream;
 	}
 
 //	public boolean isIgnorePosition() {

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
@@ -31,7 +31,13 @@ public class ClientCreateTenderPayload {
 	private long quantity;
 	private long price;
 	private long ctsTenderId;
-	//So that we can catch TODO
+	/*
+	 * We can see either interval tenders or stream tenders with the latest September 2024 standard. To support this, 
+	 * we'll set these attributes initially to be null and allow the JSON serialization to populate them if they appear 
+	 * in the payload. For example, in the POST request, if we see a ctsStream object in the JSON, bridgeInterval and
+	 * bridgeExpireTime will remain null whilst ctsStream is nonNull(if all goes well). This should allow us to take
+	 * action based on what kind of tender we have.
+	 */
 	private BridgeInterval bridgeInterval = null;
 	private BridgeInstant bridgeExpireTime = null;	
 	private CtsStreamType ctsStream = null;

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
@@ -21,7 +21,6 @@ import java.time.*;
 
 import org.theenergymashuplab.cts.BridgeInstant;
 import org.theenergymashuplab.cts.BridgeInterval;
-import org.theenergymashuplab.cts.CtsStreamType;
 import org.theenergymashuplab.cts.Interval;
 import org.theenergymashuplab.cts.SideType;
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreateTenderPayload.java
@@ -38,9 +38,8 @@ public class ClientCreateTenderPayload {
 	 * bridgeExpireTime will remain null whilst ctsStream is nonNull(if all goes well). This should allow us to take
 	 * action based on what kind of tender we have.
 	 */
-	private BridgeInterval bridgeInterval = null;
-	private BridgeInstant bridgeExpireTime = null;	
-	private CtsStreamType ctsStream = null;
+	private BridgeInterval bridgeInterval;
+	private BridgeInstant bridgeExpireTime;	
 //	private boolean ignorePosition; TODO 1.01	
 
 	// Uses BridgeInterval to avoid serialization issues
@@ -155,14 +154,6 @@ public class ClientCreateTenderPayload {
 
 	public void setBridgeExpireTime(BridgeInstant bridgeExpireTime) {
 		this.bridgeExpireTime = bridgeExpireTime;
-	}
-
-	public CtsStreamType getCtsStream(){
-		return this.ctsStream;
-	}
-
-	public void setCtsStream(CtsStreamType ctsStream){
-		this.ctsStream = ctsStream;
 	}
 
 //	public boolean isIgnorePosition() {

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamQuotePayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamQuotePayload.java
@@ -1,0 +1,56 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+import java.util.List;
+
+public class ClientCreatedStreamQuotePayload {
+    private List<EiCreatedQuotePayload> ctsStreamQuotesIds;
+    private Boolean success = false;
+    private String info = "ClientCreatedStreamQuotePayload";
+
+    public ClientCreatedStreamQuotePayload() {
+    }
+
+    public ClientCreatedStreamQuotePayload(List<EiCreatedQuotePayload> ctsStreamQuotesIds) {
+        this.ctsStreamQuotesIds = ctsStreamQuotesIds;
+        this.success = true;
+    }
+
+    public ClientCreatedStreamQuotePayload(List<EiCreatedQuotePayload> ctsStreamQuotesIds, Boolean success, String info) {
+        this.ctsStreamQuotesIds = ctsStreamQuotesIds;
+        this.success = success;
+        this.info = info;
+    }
+
+    public List<EiCreatedQuotePayload> getCtsStreamQuotesIds() {
+        return ctsStreamQuotesIds;
+    }
+
+    public void setCtsStreamQuotesIds(List<EiCreatedQuotePayload> ctsStreamQuotesIds) {
+        this.ctsStreamQuotesIds = ctsStreamQuotesIds;
+    }
+
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+
+    public String getInfo() {
+        return info;
+    }
+
+    public void setInfo(String info) {
+        this.info = info;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientCreatedStreamQuotePayload{" +
+                "ctsStreamQuotesIds=" + ctsStreamQuotesIds +
+                ", success=" + success +
+                ", info='" + info + '"' +
+        '}';
+    }
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -1,8 +1,52 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
 public class ClientCreatedStreamTenderPayload{
-	//JSON
-	public ClientCreatedStreamTenderPayload(){
+	long ctsStreamTenderId;
+	private Boolean success = false;
+	private String info = "ClientCreatedStreamTenderPayload";
 
+	//JSON
+	public ClientCreatedStreamTenderPayload(long id){
+		this.ctsStreamTenderId = id;
+		this.success = true;
+	}
+
+	public ClientCreatedStreamTenderPayload(long ctsStreamTenderId, Boolean success, String info) {
+		this.ctsStreamTenderId = ctsStreamTenderId;
+		this.success = success;
+		this.info = info;
+	}
+
+	public long getCtsStreamTenderId() {
+		return ctsStreamTenderId;
+	}
+
+	public void setCtsStreamTenderId(long ctsStreamTenderId) {
+		this.ctsStreamTenderId = ctsStreamTenderId;
+	}
+
+	public Boolean getSuccess() {
+		return success;
+	}
+
+	public void setSuccess(Boolean success) {
+		this.success = success;
+	}
+
+	public String getInfo() {
+		return info;
+	}
+
+	public void setInfo(String info) {
+		this.info = info;
+	}
+
+	@Override
+	public String toString() {
+		return "ClientCreatedStreamTenderPayload{" +
+				"ctsStreamTenderId=" + ctsStreamTenderId +
+				", success=" + success +
+				", info='" + info + '\'' +
+				'}';
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -3,7 +3,8 @@ package org.theenergymashuplab.cts.controller.payloads;
 import java.util.List;
 
 public class ClientCreatedStreamTenderPayload{
-	private List<Long> ctsStreamTenderIds;
+	//We will return a list of all of the created tenders that we made
+	private List<EiCreatedTenderPayload> ctsStreamTenderIds;
 	private Boolean success = false;
 	private String info = "ClientCreatedStreamTenderPayload";
 
@@ -11,22 +12,22 @@ public class ClientCreatedStreamTenderPayload{
 	public ClientCreatedStreamTenderPayload() {
 	}
 
-	public ClientCreatedStreamTenderPayload(List<Long> ctsStreamTenderIds){
+	public ClientCreatedStreamTenderPayload(List<EiCreatedTenderPayload> ctsStreamTenderIds){
 		this.ctsStreamTenderIds = ctsStreamTenderIds;
 		this.success = true;
 	}
 
-	public ClientCreatedStreamTenderPayload(List<Long> ctsStreamTenderIds, Boolean success, String info) {
+	public ClientCreatedStreamTenderPayload(List<EiCreatedTenderPayload> ctsStreamTenderIds, Boolean success, String info) {
 		this.ctsStreamTenderIds = ctsStreamTenderIds;
 		this.success = success;
 		this.info = info;
 	}
 
-	public List<Long> getCtsStreamTenderId() {
+	public List<EiCreatedTenderPayload> getCtsStreamTenderId() {
 		return this.ctsStreamTenderIds;
 	}
 
-	public void setCtsStreamTenderId(List<Long> ctsStreamTenderIds) {
+	public void setCtsStreamTenderId(List<EiCreatedTenderPayload> ctsStreamTenderIds) {
 		this.ctsStreamTenderIds = ctsStreamTenderIds;
 	}
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -6,10 +6,17 @@ public class ClientCreatedStreamTenderPayload{
 	//We will return a list of all of the created tenders that we made
 	private List<EiCreatedTenderPayload> ctsStreamTenderIds;
 	private Boolean success = false;
+	private long id;
 	private String info = "ClientCreatedStreamTenderPayload";
 
 	//JSON
 	public ClientCreatedStreamTenderPayload() {
+	}
+
+	//JSON
+	public ClientCreatedStreamTenderPayload(long id) {
+		this.id = id;
+		this.success = true;
 	}
 
 	public ClientCreatedStreamTenderPayload(List<EiCreatedTenderPayload> ctsStreamTenderIds){
@@ -37,6 +44,14 @@ public class ClientCreatedStreamTenderPayload{
 
 	public void setSuccess(Boolean success) {
 		this.success = success;
+	}
+
+	public long getId(){
+		return this.id;
+	}
+
+	public void setId(long id){
+		this.id = id;
 	}
 
 	public String getInfo() {

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -2,12 +2,14 @@ package org.theenergymashuplab.cts.controller.payloads;
 
 
 public class ClientCreatedStreamTenderPayload{
-<<<<<<< HEAD
 	long ctsStreamTenderId;
 	private Boolean success = false;
 	private String info = "ClientCreatedStreamTenderPayload";
 
 	//JSON
+	public ClientCreatedStreamTenderPayload() {
+	}
+
 	public ClientCreatedStreamTenderPayload(long id){
 		this.ctsStreamTenderId = id;
 		this.success = true;
@@ -18,6 +20,8 @@ public class ClientCreatedStreamTenderPayload{
 		this.success = success;
 		this.info = info;
 	}
+
+
 
 	public long getCtsStreamTenderId() {
 		return ctsStreamTenderId;
@@ -50,9 +54,5 @@ public class ClientCreatedStreamTenderPayload{
 				", success=" + success +
 				", info='" + info + '\'' +
 				'}';
-=======
-	//JSON
-	public ClientCreatedStreamTenderPayload(){
->>>>>>> 7f05e5383bd317242a12aa683c7abcc80db366df
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class ClientCreatedStreamTenderPayload{
 	//We will return a list of all of the created tenders that we made
-	private List<EiCreatedTenderPayload> ctsStreamTenderIds;
+	private List<Long> ctsStreamTenderIds;
 	private Boolean success = false;
 	private long id;
 	private String info = "ClientCreatedStreamTenderPayload";
@@ -19,22 +19,22 @@ public class ClientCreatedStreamTenderPayload{
 		this.success = true;
 	}
 
-	public ClientCreatedStreamTenderPayload(List<EiCreatedTenderPayload> ctsStreamTenderIds){
+	public ClientCreatedStreamTenderPayload(List<Long> ctsStreamTenderIds){
 		this.ctsStreamTenderIds = ctsStreamTenderIds;
 		this.success = true;
 	}
 
-	public ClientCreatedStreamTenderPayload(List<EiCreatedTenderPayload> ctsStreamTenderIds, Boolean success, String info) {
+	public ClientCreatedStreamTenderPayload(List<Long> ctsStreamTenderIds, Boolean success, String info) {
 		this.ctsStreamTenderIds = ctsStreamTenderIds;
 		this.success = success;
 		this.info = info;
 	}
 
-	public List<EiCreatedTenderPayload> getCtsStreamTenderId() {
+	public List<Long> getCtsStreamTenderId() {
 		return this.ctsStreamTenderIds;
 	}
 
-	public void setCtsStreamTenderId(List<EiCreatedTenderPayload> ctsStreamTenderIds) {
+	public void setCtsStreamTenderId(List<Long> ctsStreamTenderIds) {
 		this.ctsStreamTenderIds = ctsStreamTenderIds;
 	}
 

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -1,0 +1,8 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+public class ClientCreatedStreamTenderPayload{
+	//JSON
+	public ClientCreatedStreamTenderPayload(){
+
+	}
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/ClientCreatedStreamTenderPayload.java
@@ -1,8 +1,9 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
+import java.util.List;
 
 public class ClientCreatedStreamTenderPayload{
-	long ctsStreamTenderId;
+	private List<Long> ctsStreamTenderIds;
 	private Boolean success = false;
 	private String info = "ClientCreatedStreamTenderPayload";
 
@@ -10,25 +11,23 @@ public class ClientCreatedStreamTenderPayload{
 	public ClientCreatedStreamTenderPayload() {
 	}
 
-	public ClientCreatedStreamTenderPayload(long id){
-		this.ctsStreamTenderId = id;
+	public ClientCreatedStreamTenderPayload(List<Long> ctsStreamTenderIds){
+		this.ctsStreamTenderIds = ctsStreamTenderIds;
 		this.success = true;
 	}
 
-	public ClientCreatedStreamTenderPayload(long ctsStreamTenderId, Boolean success, String info) {
-		this.ctsStreamTenderId = ctsStreamTenderId;
+	public ClientCreatedStreamTenderPayload(List<Long> ctsStreamTenderIds, Boolean success, String info) {
+		this.ctsStreamTenderIds = ctsStreamTenderIds;
 		this.success = success;
 		this.info = info;
 	}
 
-
-
-	public long getCtsStreamTenderId() {
-		return ctsStreamTenderId;
+	public List<Long> getCtsStreamTenderId() {
+		return this.ctsStreamTenderIds;
 	}
 
-	public void setCtsStreamTenderId(long ctsStreamTenderId) {
-		this.ctsStreamTenderId = ctsStreamTenderId;
+	public void setCtsStreamTenderId(List<Long> ctsStreamTenderIds) {
+		this.ctsStreamTenderIds = ctsStreamTenderIds;
 	}
 
 	public Boolean getSuccess() {
@@ -50,7 +49,7 @@ public class ClientCreatedStreamTenderPayload{
 	@Override
 	public String toString() {
 		return "ClientCreatedStreamTenderPayload{" +
-				"ctsStreamTenderId=" + ctsStreamTenderId +
+				"ctsStreamTenderIds=" + ctsStreamTenderIds.toString() +
 				", success=" + success +
 				", info='" + info + '\'' +
 				'}';

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateQuotePayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateQuotePayload.java
@@ -45,6 +45,12 @@ public class EiCreateQuotePayload {
 		this.segmentId = segmentId;
 	}
 
+	public EiCreateQuotePayload(EiQuoteType quote, ActorIdType actorId, ActorIdType lmePartyId) {
+		this.quote = quote;
+		this.partyId = actorId;
+		this.counterPartyId = lmePartyId;
+	}
+
 	public boolean getAtMostOne(){
 		return this.atMostOne;
 	}
@@ -134,18 +140,19 @@ public class EiCreateQuotePayload {
 	}
 
 	@Override
-	public String toString(){
-		return "EiCreatedQuotePayload [" +
-				"atMostOne=" + this.atMostOne +
-				"counterPartyId=" + this.counterPartyId.toString() +
-				"executionInstructions=" + this.executionInstructions +
-				"marketId=" + this.marketId.toString() +
-				"partyId=" + this.partyId.toString() +
-				"quote=" + this.quote.toString() +
-				"requestId=" + this.requestId.toString() +
-				"requestPrivate=" + this.requestPrivate +
-				"requestPublication=" + this.requestPublication +
-				"resourceDesignator=" + this.resourceDesignator +
-				"segmentId=" + this.segmentId + "]";
+	public String toString() {
+		return "EiCreateQuotePayload{" +
+				"atMostOne=" + atMostOne +
+				", counterPartyId=" + counterPartyId +
+				", executionInstructions='" + executionInstructions + '\'' +
+				", marketId=" + marketId +
+				", partyId=" + partyId +
+				", quote=" + quote +
+				", requestId=" + requestId +
+				", requestPrivate=" + requestPrivate +
+				", requestPublication=" + requestPublication +
+				", resourceDesignator=" + resourceDesignator +
+				", segmentId=" + segmentId +
+				'}';
 	}
 }

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateStreamQuotePayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateStreamQuotePayload.java
@@ -1,0 +1,107 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+import org.theenergymashuplab.cts.*;
+
+public class EiCreateStreamQuotePayload{
+    private String executionInstructions = "";
+    private MarketIdType marketId = new MarketIdType();  // Should be provided externally
+    private int segmentId = 1;  // Assumed to always be one segment, so it's always one at the moment
+
+    private ActorIdType counterPartyId;
+    private ActorIdType partyId;
+    private RefIdType requestId;
+    private EiQuoteType quote;
+
+	/*
+	@JsonIgnore
+	private final Random rand = new Random();
+	 */
+
+    /*
+     * Default constructor for JSON deserialization.
+     * TO DO change to zero Id values in ActorId and RefId constructors
+     */
+
+    public EiCreateStreamQuotePayload(){
+//        this.counterPartyId = new ActorIdType();
+//        this.partyId = new ActorIdType();
+//        this.requestId = new RefIdType();
+    }
+
+    /*
+     * Parallel for EiCreateTransaction, EiCreateTender, EiCreateStreamTender:
+     * 		pass in a completed Tender, stream tender or Transaction which includes through its Tender interval, quantity, price,
+     * 		or for EiCancelTender only the TenderId.
+     *
+     * Add party, counterParty, and requestId for the message payload.
+     */
+    public EiCreateStreamQuotePayload(EiQuoteType quote, ActorIdType party, ActorIdType counterParty) {
+        this.quote = quote;
+        this.partyId = party;
+        this.counterPartyId = counterParty;
+        this.requestId = new RefIdType();
+    }
+
+    @Override
+    public String toString() {
+        return "EiCreateStreamQuotePayload [executionInstructions=" + executionInstructions
+                + ", marketId=" + marketId + ", segmentId=" + segmentId + ", counterPartyId=" + counterPartyId
+                + ", partyId=" + partyId + ", requestId=" + requestId + ", quote=" + quote + "]";
+    }
+
+    public ActorIdType getCounterPartyId() {
+        return counterPartyId;
+    }
+
+    public void setCounterPartyId(ActorIdType counterPartyId) {
+        this.counterPartyId = counterPartyId;
+    }
+
+    public ActorIdType getPartyId() {
+        return partyId;
+    }
+
+    public void setPartyId(ActorIdType partyId) {
+        this.partyId = partyId;
+    }
+
+    public RefIdType getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(RefIdType requestId) {
+        this.requestId = requestId;
+    }
+
+    public EiQuoteType getQuote() {
+        return quote;
+    }
+
+    public void setQuote(EiQuoteType quote) {
+        this.quote = quote;
+    }
+
+    public String getExecutionInstructions() {
+        return executionInstructions;
+    }
+
+    public void setExecutionInstructions(String executionInstructions) {
+        this.executionInstructions = executionInstructions;
+    }
+
+    public MarketIdType getMarketId() {
+        return marketId;
+    }
+
+    public void setMarketId(MarketIdType marketId) {
+        this.marketId = marketId;
+    }
+
+    public int getSegmentId() {
+        return segmentId;
+    }
+
+    public void setSegmentId(int segmentId) {
+        this.segmentId = segmentId;
+    }
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateStreamTenderPayload.java
@@ -1,0 +1,110 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+import org.theenergymashuplab.cts.ActorIdType;
+import org.theenergymashuplab.cts.EiTenderType;
+import org.theenergymashuplab.cts.MarketIdType;
+import org.theenergymashuplab.cts.RefIdType;
+
+public class EiCreateStreamTenderPayload{
+	private String executionInstructions = "";  // Is not up to the March 2024 spec; executionInstructions behavior not implemented
+	private MarketIdType marketId = new MarketIdType();  // Should be provided externally
+	private int segmentId = 1;  // Assumed to always be one segment, so it's always one at the moment
+	
+	private ActorIdType counterPartyId;
+	private ActorIdType partyId;
+	private RefIdType requestId;
+	// TODO The March 2024 standard specifies that EiCreateTenderPayload should have a list of one or more tenders
+	private EiTenderType tender;
+	
+	/*
+	@JsonIgnore
+	private final Random rand = new Random();
+	 */
+	
+	/*
+	 * Default constructor for JSON deserialization.
+	 * TO DO change to zero Id values in ActorId and RefId constructors
+	 */
+	public EiCreateStreamTenderPayload(){		
+		this.counterPartyId = new ActorIdType();
+		this.partyId = new ActorIdType();
+		this.requestId = new RefIdType();
+	}
+
+	/* 
+	 * Parallel for EiCreateTransaction, EiCreateTender, EiCreateStreamTender:
+	 * 		pass in a completed Tender, stream tender or Transaction which includes through its Tender interval, quantity, price,
+	 * 		or for EiCancelTender only the TenderId.
+	 * 
+	 * Add party, counterParty, and requestId for the message payload.
+	 */
+	public EiCreateStreamTenderPayload(EiTenderType tender, ActorIdType party, ActorIdType counterParty) {
+		this.tender = tender;
+		this.partyId = party;
+		this.counterPartyId = counterParty;
+		this.requestId = new RefIdType();
+	}
+
+	@Override
+	public String toString() {
+		return "EiCreateTenderPayload [executionInstructions=" + executionInstructions
+				+ ", marketId=" + marketId + ", segmentId=" + segmentId + ", counterPartyId=" + counterPartyId
+				+ ", partyId=" + partyId + ", requestId=" + requestId + ", tender=" + tender + "]";
+	}
+
+	public ActorIdType getCounterPartyId() {
+		return counterPartyId;
+	}
+
+	public void setCounterPartyId(ActorIdType counterPartyId) {
+		this.counterPartyId = counterPartyId;
+	}
+
+	public ActorIdType getPartyId() {
+		return partyId;
+	}
+
+	public void setPartyId(ActorIdType partyId) {
+		this.partyId = partyId;
+	}
+
+	public RefIdType getRequestId() {
+		return requestId;
+	}
+
+	public void setRequestId(RefIdType requestId) {
+		this.requestId = requestId;
+	}
+
+	public EiTenderType getTender() {
+		return tender;
+	}
+
+	public void setTender(EiTenderType tender) {
+		this.tender = tender;
+	}
+
+	public String getExecutionInstructions() {
+		return executionInstructions;
+	}
+
+	public void setExecutionInstructions(String executionInstructions) {
+		this.executionInstructions = executionInstructions;
+	}
+
+	public MarketIdType getMarketId() {
+		return marketId;
+	}
+
+	public void setMarketId(MarketIdType marketId) {
+		this.marketId = marketId;
+	}
+
+	public int getSegmentId() {
+		return segmentId;
+	}
+
+	public void setSegmentId(int segmentId) {
+		this.segmentId = segmentId;
+	}
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateStreamTenderPayload.java
@@ -1,19 +1,19 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
 import org.theenergymashuplab.cts.ActorIdType;
+import org.theenergymashuplab.cts.BridgeInstant;
 import org.theenergymashuplab.cts.EiTenderType;
 import org.theenergymashuplab.cts.MarketIdType;
 import org.theenergymashuplab.cts.RefIdType;
 
 public class EiCreateStreamTenderPayload{
-	private String executionInstructions = "";  // Is not up to the March 2024 spec; executionInstructions behavior not implemented
+	private String executionInstructions = "";
 	private MarketIdType marketId = new MarketIdType();  // Should be provided externally
 	private int segmentId = 1;  // Assumed to always be one segment, so it's always one at the moment
 	
 	private ActorIdType counterPartyId;
 	private ActorIdType partyId;
 	private RefIdType requestId;
-	// TODO The March 2024 standard specifies that EiCreateTenderPayload should have a list of one or more tenders
 	private EiTenderType tender;
 	
 	/*

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateTenderPayload.java
@@ -17,7 +17,6 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
 import org.theenergymashuplab.cts.ActorIdType;
-import org.theenergymashuplab.cts.CtsStreamType;
 import org.theenergymashuplab.cts.EiTenderType;
 import org.theenergymashuplab.cts.MarketIdType;
 import org.theenergymashuplab.cts.RefIdType;

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreateTenderPayload.java
@@ -17,6 +17,7 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
 import org.theenergymashuplab.cts.ActorIdType;
+import org.theenergymashuplab.cts.CtsStreamType;
 import org.theenergymashuplab.cts.EiTenderType;
 import org.theenergymashuplab.cts.MarketIdType;
 import org.theenergymashuplab.cts.RefIdType;

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreatedStreamQuotePayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreatedStreamQuotePayload.java
@@ -1,0 +1,99 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+import org.theenergymashuplab.cts.*;
+
+import java.util.List;
+
+public class EiCreatedStreamQuotePayload{
+    private MarketOrderIdType marketOrderId = new MarketOrderIdType();
+    private ActorIdType partyId;
+    private ActorIdType counterPartyId;
+    public EiResponse response;
+    private List<Long> createdQuotes;
+
+    // Need clarification as to what this attribute refers to before changing or deleting
+    private final RefIdType refId = new RefIdType();
+    private RefIdType inResponseTo;  // May be more prudent to rename and use refID instead of this new attribute
+
+    /*
+     * Default constructor for JSON deserialization.
+     * TO DO change to zero Id values in ActorId and RefId constructors
+     */
+    public EiCreatedStreamQuotePayload()	{
+    }
+
+    public EiCreatedStreamQuotePayload(MarketOrderIdType marketOrderId, ActorIdType partyId, ActorIdType counterPartyId, EiResponse response, List<Long> createdQuotes, RefIdType inResponseTo) {
+        this.marketOrderId = marketOrderId;
+        this.partyId = partyId;
+        this.counterPartyId = counterPartyId;
+        this.response = response;
+        this.createdQuotes = createdQuotes;
+        this.inResponseTo = inResponseTo;
+    }
+
+    public void print() {
+        System.err.println(this);
+    }
+
+    public List<Long> getCreatedQuotes(){
+        return this.createdQuotes;
+    }
+
+    public void setCreatedQuotes(List<Long> createdQuotes){
+        this.createdQuotes = createdQuotes;
+    }
+
+
+    @Override
+    public String toString() {
+        return "EiCreatedQuotePayload [marketOrderId=" + marketOrderId +  ", partyId="
+                + partyId + ", counterPartyId=" + counterPartyId + ", response=" + response + ", refId=" + refId
+                + ", inResponseTo=" + inResponseTo +  ", createdTenders=" + createdQuotes + "]";
+    }
+
+    public EiResponse getResponse() {
+        return response;
+    }
+
+    public void setResponse(EiResponse response) {
+        this.response = response;
+    }
+
+    public ActorIdType getPartyId() {
+        return partyId;
+    }
+
+    public ActorIdType getCounterPartyId() {
+        return counterPartyId;
+    }
+
+    public RefIdType getRefId() {
+        return refId;
+    }
+
+    public MarketOrderIdType getMarketOrderId() {
+        return marketOrderId;
+    }
+
+    public void setMarketOrderId(MarketOrderIdType marketOrderId) {
+        this.marketOrderId = marketOrderId;
+    }
+
+    public RefIdType getInResponseTo() {
+        return inResponseTo;
+    }
+
+    public void setInResponseTo(RefIdType inResponseTo) {
+        this.inResponseTo = inResponseTo;
+    }
+
+
+    public void setPartyId(ActorIdType partyId) {
+        this.partyId = partyId;
+    }
+
+    public void setCounterPartyId(ActorIdType counterPartyId) {
+        this.counterPartyId = counterPartyId;
+    }
+
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreatedStreamTenderPayload.java
@@ -1,0 +1,109 @@
+package org.theenergymashuplab.cts.controller.payloads;
+
+import org.theenergymashuplab.cts.ActorIdType;
+import org.theenergymashuplab.cts.EiResponse;
+import org.theenergymashuplab.cts.MarketOrderIdType;
+import org.theenergymashuplab.cts.RefIdType;
+import org.theenergymashuplab.cts.TenderIdType;
+
+public class EiCreatedStreamTenderPayload{
+	private MarketOrderIdType marketOrderId = new MarketOrderIdType();
+	
+	private TenderIdType tenderId;
+	private ActorIdType partyId;
+	private ActorIdType counterPartyId;
+	public EiResponse response;
+//	public ArrayofResponses responses; NOT USED
+	
+	// Need clarification as to what this attribute refers to before changing or deleting
+	private final RefIdType refId = new RefIdType();
+	private RefIdType inResponseTo;  // May be more prudent to rename and use refID instead of this new attribute 
+
+	/*
+	 * Default constructor for JSON deserialization.
+	 * TO DO change to zero Id values in ActorId and RefId constructors
+	 */
+	public EiCreatedStreamTenderPayload()	{		
+	}
+	
+	public EiCreatedStreamTenderPayload(
+			TenderIdType tenderId,
+			ActorIdType partyId,
+			ActorIdType counterPartyId,
+			EiResponse response,
+			RefIdType inResponseTo) {
+
+		this.tenderId = tenderId;
+		this.partyId = partyId;
+		this.counterPartyId = counterPartyId;
+		this.response = response;
+		this.inResponseTo = inResponseTo;
+	}
+
+	public long getId() {
+		return tenderId.value();
+	}
+
+	public void print() {		
+		System.err.println(this);
+	}
+	
+	@Override
+	public String toString() {
+		return "EiCreatedTenderPayload [marketOrderId=" + marketOrderId + ", tenderId=" + tenderId + ", partyId="
+				+ partyId + ", counterPartyId=" + counterPartyId + ", response=" + response + ", refId=" + refId
+				+ ", inResponseTo=" + inResponseTo + "]";
+	}
+	
+	public EiResponse getResponse() {
+		return response;
+	}
+
+	public void setResponse(EiResponse response) {
+		this.response = response;
+	}
+
+	public TenderIdType getTenderId() {
+		return tenderId;
+	}
+
+	public ActorIdType getPartyId() {
+		return partyId;
+	}
+
+	public ActorIdType getCounterPartyId() {
+		return counterPartyId;
+	}
+
+	public RefIdType getRefId() {
+		return refId;
+	}
+
+	public MarketOrderIdType getMarketOrderId() {
+		return marketOrderId;
+	}
+
+	public void setMarketOrderId(MarketOrderIdType marketOrderId) {
+		this.marketOrderId = marketOrderId;
+	}
+
+	public RefIdType getInResponseTo() {
+		return inResponseTo;
+	}
+
+	public void setInResponseTo(RefIdType inResponseTo) {
+		this.inResponseTo = inResponseTo;
+	}
+
+	public void setTenderId(TenderIdType tenderId) {
+		this.tenderId = tenderId;
+	}
+
+	public void setPartyId(ActorIdType partyId) {
+		this.partyId = partyId;
+	}
+
+	public void setCounterPartyId(ActorIdType counterPartyId) {
+		this.counterPartyId = counterPartyId;
+	}
+}

--- a/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreatedStreamTenderPayload.java
+++ b/complete/src/main/java/org/theenergymashuplab/cts/controller/payloads/EiCreatedStreamTenderPayload.java
@@ -1,5 +1,7 @@
 package org.theenergymashuplab.cts.controller.payloads;
 
+import java.util.List;
+
 import org.theenergymashuplab.cts.ActorIdType;
 import org.theenergymashuplab.cts.EiResponse;
 import org.theenergymashuplab.cts.MarketOrderIdType;
@@ -8,12 +10,10 @@ import org.theenergymashuplab.cts.TenderIdType;
 
 public class EiCreatedStreamTenderPayload{
 	private MarketOrderIdType marketOrderId = new MarketOrderIdType();
-	
-	private TenderIdType tenderId;
 	private ActorIdType partyId;
 	private ActorIdType counterPartyId;
 	public EiResponse response;
-//	public ArrayofResponses responses; NOT USED
+	private List<Long> createdTenders;
 	
 	// Need clarification as to what this attribute refers to before changing or deleting
 	private final RefIdType refId = new RefIdType();
@@ -33,26 +33,30 @@ public class EiCreatedStreamTenderPayload{
 			EiResponse response,
 			RefIdType inResponseTo) {
 
-		this.tenderId = tenderId;
 		this.partyId = partyId;
 		this.counterPartyId = counterPartyId;
 		this.response = response;
 		this.inResponseTo = inResponseTo;
 	}
 
-	public long getId() {
-		return tenderId.value();
-	}
-
 	public void print() {		
 		System.err.println(this);
 	}
 	
+	public List<Long> getCreatedTenders(){
+		return this.createdTenders;
+	}
+
+	public void setCreatedTenders(List<Long> createdTenders){
+		this.createdTenders = createdTenders;
+	}
+
+
 	@Override
 	public String toString() {
-		return "EiCreatedTenderPayload [marketOrderId=" + marketOrderId + ", tenderId=" + tenderId + ", partyId="
+		return "EiCreatedTenderPayload [marketOrderId=" + marketOrderId +  ", partyId="
 				+ partyId + ", counterPartyId=" + counterPartyId + ", response=" + response + ", refId=" + refId
-				+ ", inResponseTo=" + inResponseTo + "]";
+				+ ", inResponseTo=" + inResponseTo +  ", createdTenders=" + createdTenders + "]";
 	}
 	
 	public EiResponse getResponse() {
@@ -61,10 +65,6 @@ public class EiCreatedStreamTenderPayload{
 
 	public void setResponse(EiResponse response) {
 		this.response = response;
-	}
-
-	public TenderIdType getTenderId() {
-		return tenderId;
 	}
 
 	public ActorIdType getPartyId() {
@@ -95,9 +95,6 @@ public class EiCreatedStreamTenderPayload{
 		this.inResponseTo = inResponseTo;
 	}
 
-	public void setTenderId(TenderIdType tenderId) {
-		this.tenderId = tenderId;
-	}
 
 	public void setPartyId(ActorIdType partyId) {
 		this.partyId = partyId;


### PR DESCRIPTION
Creates new POST mappings for clientCreateStreamTender and clientCreateStreamQuote. Stream tenders make it to the market as individual tenders. Currently, stream quotes do not as quotes are not implemented in the market, but the infrastructure is now there for when they do make it to market.